### PR TITLE
index.html: fix Uncaught ReferenceError: JSONEditor is not defined

### DIFF
--- a/index.html
+++ b/index.html
@@ -19,6 +19,7 @@
   <script src='swagger-ui/dist/lib/backbone-min.js' type='text/javascript'></script>
   <script src='swagger-ui/dist/swagger-ui.js' type='text/javascript'></script>
   <script src='swagger-ui/dist/lib/highlight.7.3.pack.js' type='text/javascript'></script>
+  <script src='swagger-ui/dist/lib/jsoneditor.min.js' type='text/javascript'></script>
   <script src='swagger-ui/dist/lib/marked.js' type='text/javascript'></script>
   <script src='swagger-ui/dist/lib/swagger-oauth.js' type='text/javascript'></script>
 


### PR DESCRIPTION
Updating Swagger UI to v2.1.4 caused this new error, since this JSONEditor is a new feature.  Add the missing script import to fix it.
