### PR TITLE
github.com : autodetect raw url of .yaml files and upgrade swagger-ui to v2.2.6

### DIFF
--- a/background.js
+++ b/background.js
@@ -1,7 +1,17 @@
+function openTab (url) {
+  chrome.tabs.create({'url': chrome.extension.getURL('index.html') + '?url=' + url});
+}
+
 chrome.browserAction.onClicked.addListener(function (tab) {
   chrome.tabs.query({'active': true, 'lastFocusedWindow': true}, function (tabs) {
-    var url = tabs[0].url;
-      chrome.tabs.create({'url': chrome.extension.getURL('index.html') + '?url=' + url}, function (tab) {
-    });
+    var currentUrl = tabs[0].url;
+
+    if ((/^https:\/\/github.com\/.+\.yaml$/).test(currentUrl)) { // yaml file in github.com interface
+      chrome.tabs.executeScript(tabs[0].id, { code: 'document.querySelector("#raw-url") ? document.querySelector("#raw-url").href : null' }, function (rawUrl) {
+        openTab(rawUrl[0] || currentUrl)
+      });
+    } else {
+      openTab(currentUrl);
+    }
   });
 });

--- a/index.html
+++ b/index.html
@@ -10,36 +10,38 @@
   <link href='swagger-ui/dist/css/screen.css' media='screen' rel='stylesheet' type='text/css'/>
   <link href='swagger-ui/dist/css/reset.css' media='print' rel='stylesheet' type='text/css'/>
   <link href='swagger-ui/dist/css/print.css' media='print' rel='stylesheet' type='text/css'/>
+
+  <script src='swagger-ui/dist/lib/object-assign-pollyfill.js' type='text/javascript'></script>
   <script src='swagger-ui/dist/lib/jquery-1.8.0.min.js' type='text/javascript'></script>
   <script src='swagger-ui/dist/lib/jquery.slideto.min.js' type='text/javascript'></script>
   <script src='swagger-ui/dist/lib/jquery.wiggle.min.js' type='text/javascript'></script>
   <script src='swagger-ui/dist/lib/jquery.ba-bbq.min.js' type='text/javascript'></script>
-  <script src='swagger-ui/dist/lib/handlebars-2.0.0.js' type='text/javascript'></script>
-  <script src='swagger-ui/dist/lib/underscore-min.js' type='text/javascript'></script>
+  <script src='swagger-ui/dist/lib/handlebars-4.0.5.js' type='text/javascript'></script>
+  <script src='swagger-ui/dist/lib/lodash.min.js' type='text/javascript'></script>
   <script src='swagger-ui/dist/lib/backbone-min.js' type='text/javascript'></script>
   <script src='swagger-ui/dist/swagger-ui.js' type='text/javascript'></script>
-  <script src='swagger-ui/dist/lib/highlight.7.3.pack.js' type='text/javascript'></script>
+  <script src='swagger-ui/dist/lib/highlight.9.1.0.pack.js' type='text/javascript'></script>
+  <script src='swagger-ui/dist/lib/highlight.9.1.0.pack_extended.js' type='text/javascript'></script>
   <script src='swagger-ui/dist/lib/jsoneditor.min.js' type='text/javascript'></script>
   <script src='swagger-ui/dist/lib/marked.js' type='text/javascript'></script>
   <script src='swagger-ui/dist/lib/swagger-oauth.js' type='text/javascript'></script>
 
   <!-- Some basic translations -->
-  <!-- <script src=''swagger-ui/dist/lang/translator.js' type='text/javascript'></script> -->
-  <!-- <script src=''swagger-ui/dist/lang/ru.js' type='text/javascript'></script> -->
-  <!-- <script src=''swagger-ui/dist/lang/en.js' type='text/javascript'></script> -->
+  <!-- <script src='lang/translator.js' type='text/javascript'></script> -->
+  <!-- <script src='lang/ru.js' type='text/javascript'></script> -->
+  <!-- <script src='lang/en.js' type='text/javascript'></script> -->
 
-  <script src='index.js' type='text/javascript'></script>
-
+  <script src='index.js' type="text/javascript"></script>
 </head>
 
 <body class="swagger-section">
    <div id='header'>
      <div class="swagger-ui-wrap">
-       <a id="logo" href="http://swagger.io">swagger</a>
+       <a id="logo" href="http://swagger.io"><img class="logo__img" alt="swagger" height="30" width="30" src="swagger-ui/dist/images/logo_small.png" /><span class="logo__title">swagger</span></a>
        <form id='api_selector'>
          <div class='input'><input placeholder="http://example.com/api" id="input_baseUrl" name="baseUrl" type="text"/></div>
-         <div class='input'><input placeholder="api_key" id="input_apiKey" name="apiKey" type="text"/></div>
-         <div class='input'><a id="explore" href="#" data-sw-translate>Explore</a></div>
+         <div id='auth_container'></div>
+         <div class='input'><a id="explore" class="header__btn" href="#" data-sw-translate>Explore</a></div>
        </form>
      </div>
    </div>

--- a/index.js
+++ b/index.js
@@ -1,11 +1,14 @@
- $(function () {
-
+  $(function () {
    var url = window.location.search.match(/url=([^&]+)/);
    if (url && url.length > 1) {
      url = decodeURIComponent(url[1]);
    } else {
      url = "http://petstore.swagger.io/v2/swagger.json";
    }
+
+   hljs.configure({
+     highlightSizeThreshold: 5000
+   });
 
    // Pre load translate...
    if(window.SwaggerTranslator) {
@@ -19,47 +22,26 @@
        if(typeof initOAuth == "function") {
          initOAuth({
            clientId: "your-client-id",
-           clientSecret: "your-client-secret",
+           clientSecret: "your-client-secret-if-required",
            realm: "your-realms",
-           appName: "your-app-name", 
-           scopeSeparator: ","
+           appName: "your-app-name",
+           scopeSeparator: " ",
+           additionalQueryStringParams: {}
          });
        }
 
        if(window.SwaggerTranslator) {
          window.SwaggerTranslator.translate();
        }
-
-       $('pre code').each(function(i, e) {
-         hljs.highlightBlock(e)
-       });
-
-       addApiKeyAuthorization();
      },
      onFailure: function(data) {
        log("Unable to Load SwaggerUI");
      },
      docExpansion: "none",
-     apisSorter: "alpha",
+     jsonEditor: false,
+     defaultModelRendering: 'schema',
      showRequestHeaders: false
    });
-
-   function addApiKeyAuthorization(){
-     var key = encodeURIComponent($('#input_apiKey')[0].value);
-     if(key && key.trim() != "") {
-         var apiKeyAuth = new SwaggerClient.ApiKeyAuthorization("api_key", key, "query");
-         window.swaggerUi.api.clientAuthorizations.add("api_key", apiKeyAuth);
-         log("added key " + key);
-     }
-   }
-
-   $('#input_apiKey').change(addApiKeyAuthorization);
-
-   // if you have an apiKey you would like to pre-populate on the page for demonstration purposes...
-   /*
-     var apiKey = "myApiKeyXXXX123456789";
-     $('#input_apiKey').val(apiKey);
-   */
 
    window.swaggerUi.load();
 
@@ -68,4 +50,4 @@
        console.log.apply(console, arguments);
      }
    }
-});
+ });


### PR DESCRIPTION
Hi,

- Upgrade to Swagger-ui v2.2.6
- New behavior for the .yaml files seen from github.com : autodetection of the raw url. Failback to the initial behavior if the script fails to defined the raw url.

Exemple of page auto-detected : https://github.com/OAI/OpenAPI-Specification/blob/master/examples/v2.0/yaml/petstore.yaml